### PR TITLE
Prevents packing *.razor files

### DIFF
--- a/src/Blazor.Extensions.Canvas/Blazor.Extensions.Canvas.csproj
+++ b/src/Blazor.Extensions.Canvas/Blazor.Extensions.Canvas.csproj
@@ -31,4 +31,10 @@
     </ItemGroup>
   </Target>
 
+  <ItemGroup>
+    <Content Update="**\*.razor">
+      <Pack>false</Pack>
+    </Content>
+  </ItemGroup>
+  
 </Project>


### PR DESCRIPTION
Prevents BECanvas.razor from being published in the Nuget package.

![image](https://user-images.githubusercontent.com/9521987/59121695-af4ab600-890d-11e9-9409-1d4f969dff73.png)
