### PR TITLE
Updated to use the released version (3.1.1) of Blazor

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Both Canvas 2D and WebGL are supported.
 
 Both Blazor Server Apps and Blazor WebAssembly Apps are supported.
 
-**NOTE** Currently targets the v3.0.0-preview8 version of Blazor.
+Currently targets the v3.1.1 version of Blazor.
 
 # Installation
 

--- a/src/Blazor.Extensions.Canvas/Blazor.Extensions.Canvas.csproj
+++ b/src/Blazor.Extensions.Canvas/Blazor.Extensions.Canvas.csproj
@@ -20,7 +20,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.Components.Web" Version="3.1.0-preview1.19508.20" />
+    <PackageReference Include="Microsoft.AspNetCore.Components.Web" Version="3.1.1" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Just changed the `.csproj` file and the `README.md` file.

This will help those users who are using 3.1.1 as, currently, those users are faced with several package downgrade error when installing the nuget package