### PR TITLE
Renamed Primitive.TRINAGLE_STRIP to Primitive.TRIANGLE_STRIP

### DIFF
--- a/src/Blazor.Extensions.Canvas/WebGL/WebGLEnums.cs
+++ b/src/Blazor.Extensions.Canvas/WebGL/WebGLEnums.cs
@@ -14,7 +14,7 @@ namespace Blazor.Extensions.Canvas.WebGL
         LINE_LOOP = 2,
         LINE_STRIP = 3,
         TRIANGLES = 4,
-        TRINAGLE_STRIP = 5,
+        TRIANGLE_STRIP = 5,
         TRIANGLE_FAN = 6
     }
 


### PR DESCRIPTION
Renamed Primitive.TRINAGLE_STRIP to Primitive.TRIANGLE_STRIP so that IntelliSense picks it up easily.

Found this when following a WebGL tutorial from MDN using your wonderful library.

Change was done using VS Rename and didn't pick up any references, so seems good to go in?

Please let me know if you need any other info or anything clarifying.

Thanks very much