### PR TITLE
Update BECanvasComponent.cs

### DIFF
--- a/src/Blazor.Extensions.Canvas/BECanvasComponent.cs
+++ b/src/Blazor.Extensions.Canvas/BECanvasComponent.cs
@@ -12,7 +12,7 @@ namespace Blazor.Extensions
         [Parameter]
         public long Width { get; set; }
 
-        protected readonly string Id = Guid.NewGuid().ToString();
+        public readonly string Id = Guid.NewGuid().ToString();
         protected ElementReference _canvasRef;
 
         internal ElementReference CanvasReference => this._canvasRef;


### PR DESCRIPTION
Exposed Id so component can be found in Javascript.  Will be helpful when trying to get the canvas size at runtime:

document.getElementById(canvasElementId).getBoundingClientRect();