### PR TITLE
enable subclasses and extension methods

### DIFF
--- a/src/Blazor.Extensions.Canvas/Canvas2D/Canvas2DContext.cs
+++ b/src/Blazor.Extensions.Canvas/Canvas2D/Canvas2DContext.cs
@@ -98,7 +98,7 @@ namespace Blazor.Extensions.Canvas.Canvas2D
 
         #endregion Properties
 
-        internal Canvas2DContext(BECanvasComponent reference) : base(reference, CONTEXT_NAME)
+        public Canvas2DContext(BECanvasComponent reference) : base(reference, CONTEXT_NAME)
         {
         }
 

--- a/src/Blazor.Extensions.Canvas/WebGL/WebGLContext.cs
+++ b/src/Blazor.Extensions.Canvas/WebGL/WebGLContext.cs
@@ -125,7 +125,7 @@ namespace Blazor.Extensions.Canvas.WebGL
         public int DrawingBufferHeight { get; private set; }
         #endregion
 
-        internal WebGLContext(BECanvasComponent reference, WebGLContextAttributes attributes = null) : base(reference, CONTEXT_NAME, attributes)
+        public WebGLContext(BECanvasComponent reference, WebGLContextAttributes attributes = null) : base(reference, CONTEXT_NAME, attributes)
         {
         }
 


### PR DESCRIPTION
I have marked the classes as public in order to enable subclassing and extension methods:

```
public class ContextExt : Canvas2D.Canvas2DContext
{
    public ContextExt(BECanvasComponent reference) : base(reference)
    {
    }

    public async Task CreateImageDataAsync(int width, int height) => await this.CallMethodAsync<ImageData>("createImageData", width, height);
}

public class ImageData
{
    public byte[] Data { get; set; }
    public int Width { get; set; }
    public int Height { get; set; }
}
```